### PR TITLE
add is-pwa-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 - [Can I Use - Service Workers](http://caniuse.com/#feat=serviceworkers) - Up-to-date browser support table of ServiceWorker API.
 - [Is Service Worker ready?](https://jakearchibald.github.io/isserviceworkerready/) - Current status of ServiceWorker support in different browsers.
+- [Toxic Johann - Is PWA ready ?](https://ispwaready.toxicjohann.com) - Current status of Progressive Web App support in different browsers (including Chinese browsers and auto test page).
 
 ## Videos
 


### PR DESCRIPTION
Current status of Progressive Web App support in different browsers (including Chinese browsers and auto test page).